### PR TITLE
Fix #762 - Start Player Freezes the app

### DIFF
--- a/android/src/main/java/xyz/canardoux/TauNative/FlautoPlayer.java
+++ b/android/src/main/java/xyz/canardoux/TauNative/FlautoPlayer.java
@@ -422,7 +422,7 @@ public class FlautoPlayer extends FlautoSession implements MediaPlayer.OnErrorLi
 			{
 
 			}
-			player._play();
+//			player._play();
 			return true;
 	}
 

--- a/android/src/main/java/xyz/canardoux/TauNative/FlautoPlayerMedia.java
+++ b/android/src/main/java/xyz/canardoux/TauNative/FlautoPlayerMedia.java
@@ -37,24 +37,32 @@ class FlautoPlayerMedia extends FlautoPlayerEngineInterface
 	}
 
 	void _startPlayer(String path,  int sampleRate, int numChannels, int blockSize, FlautoPlayer theSession) throws Exception
- 	{
-		this.flautoPlayer = theSession;
- 		mediaPlayer = new MediaPlayer();
+	{
 		if (path == null)
 		{
 			throw new Exception("path is NULL");
 		}
+		this.flautoPlayer = theSession;
+		mediaPlayer = new MediaPlayer();
+
 		mediaPlayer.setDataSource(path);
-		final String pathFile = path;
 		mediaPlayer.setOnPreparedListener(mp -> {flautoPlayer.play(); flautoPlayer.onPrepared();});
 		mediaPlayer.setOnCompletionListener(mp -> flautoPlayer.onCompletion());
-		mediaPlayer.setOnErrorListener(flautoPlayer);
-		mediaPlayer.prepare();
+		mediaPlayer.setOnErrorListener((mp, what, extra) -> {
+			flautoPlayer.onError(mp, what, extra);
+			flautoPlayer.onPrepared();
+			return  false;
+		});
+		mediaPlayer.prepareAsync();
 	}
 
 	void _play()
 	{
-		mediaPlayer.start();
+		mediaPlayer.setOnPreparedListener(mp -> {
+			flautoPlayer.play();
+			flautoPlayer.onPrepared();
+			mp.start();
+		});
 	}
 
 	int feed(byte[] data) throws Exception

--- a/android/src/main/java/xyz/canardoux/TauNative/FlautoPlayerMedia.java
+++ b/android/src/main/java/xyz/canardoux/TauNative/FlautoPlayerMedia.java
@@ -46,7 +46,7 @@ class FlautoPlayerMedia extends FlautoPlayerEngineInterface
 		mediaPlayer = new MediaPlayer();
 
 		mediaPlayer.setDataSource(path);
-		mediaPlayer.setOnPreparedListener(mp -> {flautoPlayer.play(); flautoPlayer.onPrepared();});
+		mediaPlayer.setOnPreparedListener(mp -> {flautoPlayer.play(); _play(); flautoPlayer.onPrepared();});
 		mediaPlayer.setOnCompletionListener(mp -> flautoPlayer.onCompletion());
 		mediaPlayer.setOnErrorListener((mp, what, extra) -> {
 			flautoPlayer.onError(mp, what, extra);
@@ -58,11 +58,7 @@ class FlautoPlayerMedia extends FlautoPlayerEngineInterface
 
 	void _play()
 	{
-		mediaPlayer.setOnPreparedListener(mp -> {
-			flautoPlayer.play();
-			flautoPlayer.onPrepared();
-			mp.start();
-		});
+		mediaPlayer.start();
 	}
 
 	int feed(byte[] data) throws Exception


### PR DESCRIPTION
Fix [#762](https://github.com/Canardoux/flutter_sound/issues/762)

I changed the way the player loads audio.
Previously, it loaded audio synchronously and caused the app to freeze while it loaded.
Now it loads the data asynchronously without freezing the application and then through a callback starts the player.